### PR TITLE
[RFC][WIP] Use keyring from user namespace for verification

### DIFF
--- a/security/integrity/digsig.c
+++ b/security/integrity/digsig.c
@@ -38,10 +38,19 @@ static const char * const keyring_name[INTEGRITY_KEYRING_MAX] = {
 #define restrict_link_to_ima restrict_link_by_builtin_trusted
 #endif
 
+extern struct key *find_keyring_by_name(const char *name, bool uid_keyring);
+
 static struct key *integrity_keyring_from_id(const unsigned int id)
 {
+	struct key *ns_key;
+
 	if (id >= INTEGRITY_KEYRING_MAX)
 		return ERR_PTR(-EINVAL);
+
+	/* Travers through keyrings. It calls current_user_ns() inside. */
+	ns_key = find_keyring_by_name(keyring_name[id], false);
+	if (!IS_ERR(ns_key))
+		return ns_key;
 
 	if (!keyring[id]) {
 		keyring[id] =

--- a/security/keys/keyring.c
+++ b/security/keys/keyring.c
@@ -110,7 +110,9 @@ static void keyring_publish_name(struct key *keyring)
 
 	if (keyring->description &&
 	    keyring->description[0] &&
-	    keyring->description[0] != '.') {
+	    keyring->description[0] != '.') { /* In this case we cannot insert
+						 new .ima keyring in user
+						 namespace */
 		write_lock(&keyring_name_lock);
 		list_add_tail(&keyring->name_link, &ns->keyring_name_list);
 		write_unlock(&keyring_name_lock);


### PR DESCRIPTION
 This is the attempt to use keyring which is associated
 with corresponding user namespace.
 Since IMA-ns is included in user namespace. That user namespace
 could have its own keyrings. Then that keyrings could be
 used for IMA verification.

Signed-off-by: Denis Semakin <denis.semakin@huawei.com>

First of all I'd like to ask about comments for this code:
1. Is it okay to use user namespace keyrings for IMA verification?
2. Will we trust that keyrings?
3. Is this the correct place for adding this functionality?
4. Any other thoughts and your opinion are welcome
